### PR TITLE
docs: add felo-youtube-subtitling to skills index

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,14 @@ Real-time web search with AI-generated answers.
 
 Generate PPT: in terminal use `felo slides "your topic"`, in Claude Code use `/felo-slides your topic`. **[View skill documentation →](./felo-slides/)**
 
+### felo-web-fetch
+
+Fetch and extract webpage content: in terminal use `felo web-fetch --url "https://example.com"`, in Claude Code use `/felo-web-fetch https://example.com`. **[View skill documentation →](./felo-web-fetch/)**
+
+### felo-youtube-subtitling
+
+Fetch YouTube subtitles by video URL or ID: in terminal use `felo youtube-subtitling -v "URL_or_VIDEO_ID"`, in Claude Code use `/felo-youtube-subtitling URL_or_VIDEO_ID`. **[View skill documentation →](./felo-youtube-subtitling/)**
+
 ---
 
 ## Contributing


### PR DESCRIPTION
## What
- add `felo-youtube-subtitling` entry to root README available skills index

## Validation
- verified YouTube subtitling script works with public video and test API key:
  - `FELO_API_KEY=*** node felo-youtube-subtitling/scripts/run_youtube_subtitling.mjs -v "dQw4w9WgXcQ" --language en --with-time`

## Notes
- the skill files already exist on `main` (from prior merge); this PR updates the index so the skill is discoverable.
