### PR TITLE
🐛 fix: 修复 felo-x-search API 路径缺少 /v2 前缀 (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.10] - 2026-03-10
+
+### Fixed
+
+- 修复 `felo-x-search` API 请求路径缺少 `/v2` 前缀的问题。
+
+---
+
 ## [0.2.7] - 2025-03-06
 
 ### Breaking Changes
@@ -26,5 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Earlier releases: search, slides, web fetch, youtube-subtitling features.
 
+[0.2.10]: https://github.com/Felo-Inc/felo-skills/compare/v0.2.9...v0.2.10
 [0.2.7]: https://github.com/Felo-Inc/felo-skills/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/Felo-Inc/felo-skills/releases/tag/v0.2.6

--- a/felo-x-search/scripts/run_x_search.mjs
+++ b/felo-x-search/scripts/run_x_search.mjs
@@ -62,7 +62,7 @@ async function fetchWithRetry(url, init, timeoutMs) {
 
 async function postApi(apiBase, apiKey, path, body, timeoutMs) {
   const res = await fetchWithRetry(
-    `${apiBase}${path}`,
+    `${apiBase}/v2${path}`,
     {
       method: 'POST',
       headers: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "felo-ai",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Felo AI CLI - real-time search, PPT generation, web fetch, and YouTube subtitles from the terminal",
   "type": "module",
   "main": "src/cli.js",


### PR DESCRIPTION
## 描述

修复 `felo-x-search` 的 `postApi` 函数中 API 请求路径缺少 `/v2` 前缀的问题。

## 变更内容

- 修正 `felo-x-search/scripts/run_x_search.mjs` 中请求路径为 `/v2` 前缀
- 版本升级至 `0.2.10`
- 更新 CHANGELOG

Relates to #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)