### PR TITLE
♻️ refactor(felo-superAgent): remove livedoc API endpoints from skill docs

### DIFF
--- a/felo-superAgent/README.md
+++ b/felo-superAgent/README.md
@@ -1,8 +1,8 @@
 # Felo SuperAgent Skill for Claude Code
 
-**AI 对话与流式输出，支持 LiveDoc 与连续会话。**
+**AI 对话与流式输出，支持连续会话。**
 
-通过 Felo Open Platform 的 SuperAgent API，在 Claude Code 中发起与 SuperAgent 的对话、接收 SSE 流式回复，并可关联 LiveDoc、查询会话详情与资源。
+通过 Felo Open Platform 的 SuperAgent API，在 Claude Code 中发起与 SuperAgent 的对话、接收 SSE 流式回复，并可查询会话详情。
 
 ---
 
@@ -24,6 +24,7 @@
 - 仅需单次实时信息检索 → 使用 `felo-search`
 - 仅需抓取网页正文 → 使用 `felo-web-fetch`
 - 仅需生成 PPT → 使用 `felo-slides`
+- 需要 LiveDoc 知识库功能 → 使用 `felo-livedoc`
 
 ---
 
@@ -115,7 +116,7 @@ node felo-superAgent/scripts/run_superagent.mjs --query "What is the latest news
 }
 ```
 
-可用 `thread_short_id` 调用「查询会话详情」接口，用 `live_doc_short_id` 调用「列举 LiveDoc 资源」等接口。
+可用 `thread_short_id` 调用「查询会话详情」接口，`live_doc_short_id` 可传入 `felo-livedoc` 查询相关资源。
 
 ---
 

--- a/felo-superAgent/SKILL.md
+++ b/felo-superAgent/SKILL.md
@@ -10,9 +10,9 @@ description: "Felo SuperAgent API: AI conversation with real-time SSE streaming 
 Trigger this skill for:
 
 - **SuperAgent 对话**：需要与 Felo SuperAgent 进行 AI 对话、流式输出
-- **LiveDoc 集成**：希望回答与 LiveDoc 关联、可追溯资源
-- **连续对话**：在已有会话/文档上继续提问（传入 `live_doc_short_id`）
-- **多轮对话**：需要 thread_short_id / live_doc_short_id 以便后续查询会话详情或 LiveDoc 资源
+- **LiveDoc 关联**：每次会话对应一个 LiveDoc，可后续查看资源
+- **连续对话**：在已有 LiveDoc 上继续提问（传入 `live_doc_short_id`）
+- **多轮对话**：需要 thread_short_id / live_doc_short_id 以便后续查询会话详情
 
 **Trigger words / 触发词：**
 
@@ -25,6 +25,7 @@ Trigger this skill for:
 - 简单单次问答、实时信息查询（优先用 `felo-search`）
 - 仅需抓取网页内容（用 `felo-web-fetch`）
 - 仅需生成 PPT（用 `felo-slides`）
+- 需要 LiveDoc 知识库功能（用 `felo-livedoc`）
 
 ## Setup
 
@@ -83,8 +84,8 @@ node felo-superAgent/scripts/run_superagent.mjs \
 
 Optional:
 
-- **Reuse LiveDoc (连续对话):** `--live-doc-id "PvyKouzJirXjFdst4uKRK3"`
 - **Language:** `--accept-language zh` or `--accept-language en`
+- **Reuse LiveDoc (连续对话):** `--live-doc-id "PvyKouzJirXjFdst4uKRK3"`
 - **JSON output:** `--json` (includes thread_short_id, live_doc_short_id, full answer)
 - **Verbose:** `--verbose` (logs stream connection to stderr)
 
@@ -123,8 +124,6 @@ If the user asked for conversation detail or LiveDoc resources, you can call the
 1. **POST** `/v2/conversations` → get `stream_key`, `thread_short_id`, `live_doc_short_id`
 2. **GET** `/v2/conversations/stream/{stream_key}` → consume SSE until `done` or `error`
 3. Optionally: **GET** `/v2/conversations/{thread_short_id}` → conversation detail
-4. Optionally: **GET** `/v2/livedocs` → list LiveDocs
-5. Optionally: **GET** `/v2/livedocs/{live_doc_short_id}/resources` → list resources
 
 Base URL: `https://openapi.felo.ai` (override with `FELO_API_BASE` if needed).
 
@@ -135,8 +134,6 @@ Base URL: `https://openapi.felo.ai` (override with `FELO_API_BASE` if needed).
 | INVALID_API_KEY                        | 401  | API Key 无效或已撤销     |
 | SUPER_AGENT_CONVERSATION_CREATE_FAILED | 502  | 创建会话失败（下游错误） |
 | SUPER_AGENT_CONVERSATION_QUERY_FAILED  | 502  | 查询会话详情失败         |
-| SUPER_AGENT_LIVEDOC_LIST_FAILED        | 502  | 列举 LiveDocs 失败       |
-| SUPER_AGENT_LIVEDOC_RESOURCES_FAILED   | 502  | 列举 LiveDoc 资源失败    |
 
 SSE stream may send:
 


### PR DESCRIPTION
## Summary

- 移除 `SKILL.md` 和 `README.md` 中 `/v2/livedocs` 相关 API 接口说明
- 移除 Error Handling 中的 `SUPER_AGENT_LIVEDOC_LIST_FAILED` 和 `SUPER_AGENT_LIVEDOC_RESOURCES_FAILED` 错误码
- 新增引导：LiveDoc 知识库功能请使用 `felo-livedoc`
- 保留 `live_doc_short_id` 参数和返回值描述（SuperAgent API 本身仍会返回该字段）

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)