### PR TITLE
feat(livedoc): add route command and fix retrieve --resource-ids support

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -640,12 +640,33 @@ livedocCmd
   .command("retrieve <short_id>")
   .description("Semantic search across resources")
   .requiredOption("--query <query>", "search query")
+  .option("--resource-ids <ids>", "comma-separated resource IDs to search within")
   .option("-j, --json", "output raw JSON")
   .option("-t, --timeout <seconds>", "request timeout in seconds", "60")
   .action(async (shortId, opts) => {
     const timeoutMs = parseInt(opts.timeout, 10) * 1000;
     const code = await livedoc.retrieve(shortId, {
       query: opts.query,
+      resourceIds: opts.resourceIds,
+      json: opts.json,
+      timeoutMs: Number.isNaN(timeoutMs) ? 60000 : timeoutMs,
+    });
+    process.exitCode = code;
+    flushStdioThenExit(code);
+  });
+
+livedocCmd
+  .command("route <short_id>")
+  .description("Route relevant resource IDs by query")
+  .requiredOption("--query <query>", "routing query")
+  .option("--max-resources <n>", "max resources to return")
+  .option("-j, --json", "output raw JSON")
+  .option("-t, --timeout <seconds>", "request timeout in seconds", "60")
+  .action(async (shortId, opts) => {
+    const timeoutMs = parseInt(opts.timeout, 10) * 1000;
+    const code = await livedoc.route(shortId, {
+      query: opts.query,
+      maxResources: opts.maxResources,
       json: opts.json,
       timeoutMs: Number.isNaN(timeoutMs) ? 60000 : timeoutMs,
     });

--- a/src/livedoc.js
+++ b/src/livedoc.js
@@ -374,6 +374,36 @@ export async function removeResource(shortId, resourceId, opts = {}) {
   } finally { stopSpinner(spinnerId); }
 }
 
+export async function route(shortId, opts = {}) {
+  const apiKey = await getApiKey();
+  if (!apiKey) { console.error(NO_KEY_MESSAGE.trim()); return 1; }
+  if (!shortId) { process.stderr.write('ERROR: short_id is required.\n'); return 1; }
+  if (!opts.query) { process.stderr.write('ERROR: --query is required.\n'); return 1; }
+
+  const apiBase = await getApiBase();
+  const timeoutMs = opts.timeoutMs || DEFAULT_TIMEOUT_MS;
+  const spinnerId = startSpinner('Routing relevant resources');
+
+  try {
+    const body = { query: opts.query };
+    if (opts.maxResources) {
+      const n = parseInt(opts.maxResources, 10);
+      if (Number.isFinite(n) && n > 0) body.max_resources = n;
+    }
+    const payload = await apiRequest('POST', `/livedocs/${shortId}/resources/route`, body, apiKey, apiBase, timeoutMs);
+    if (opts.json) { console.log(JSON.stringify(payload, null, 2)); return 0; }
+
+    const resourceIds = payload?.data || [];
+    if (!resourceIds.length) { process.stderr.write('No relevant resources found.\n'); return 0; }
+    process.stdout.write(`Found ${resourceIds.length} relevant resource(s):\n\n`);
+    for (const id of resourceIds) process.stdout.write(`- ${id}\n`);
+    return 0;
+  } catch (err) {
+    process.stderr.write(`Failed to route resources: ${err?.message || err}\n`);
+    return 1;
+  } finally { stopSpinner(spinnerId); }
+}
+
 export async function retrieve(shortId, opts = {}) {
   const apiKey = await getApiKey();
   if (!apiKey) { console.error(NO_KEY_MESSAGE.trim()); return 1; }
@@ -385,7 +415,10 @@ export async function retrieve(shortId, opts = {}) {
   const spinnerId = startSpinner('Retrieving from knowledge base');
 
   try {
-    const body = { content: opts.query };
+    const body = { query: opts.query };
+    if (opts.resourceIds) {
+      body.resource_ids = opts.resourceIds.split(',').map(id => id.trim()).filter(Boolean);
+    }
     const payload = await apiRequest('POST', `/livedocs/${shortId}/resources/retrieve`, body, apiKey, apiBase, timeoutMs);
     if (opts.json) { console.log(JSON.stringify(payload, null, 2)); return 0; }
 


### PR DESCRIPTION
## Summary

- Add `route` subcommand to `felo livedoc` for routing relevant resource IDs by query (with optional `--max-resources` flag)
- Add `--resource-ids` option to `retrieve` subcommand for searching within specific resources
- Fix bug in `retrieve` where request body used `content` instead of `query`

## Test plan

- [ ] `felo livedoc -h` shows `route` and updated `retrieve` commands
- [ ] `felo livedoc route <short_id> --query "..."` returns relevant resource IDs
- [ ] `felo livedoc route <short_id> --query "..." --max-resources 3` limits results
- [ ] `felo livedoc retrieve <short_id> --query "..." --resource-ids "id1,id2"` searches within specific resources
- [ ] `felo livedoc retrieve <short_id> --query "..."` still works without `--resource-ids`

🤖 Generated with [Claude Code](https://claude.com/claude-code)