### PR TITLE
chore: add Claude Code plugin marketplace support (v0.2.29)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,85 @@
+{
+  "name": "felo-ai",
+  "owner": {
+    "name": "Felo-Inc",
+    "url": "https://github.com/Felo-Inc"
+  },
+  "metadata": {
+    "description": "Felo AI skills for Claude Code — real-time search, PPT generation, SuperAgent, LiveDoc knowledge base, web fetch, YouTube subtitles, and X (Twitter) search",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "felo-search",
+      "description": "Real-time web search powered by Felo AI",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./felo-search"
+      ]
+    },
+    {
+      "name": "felo-livedoc",
+      "description": "Manage knowledge bases (LiveDocs) and semantic retrieval via Felo API",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./felo-livedoc"
+      ]
+    },
+    {
+      "name": "felo-slides",
+      "description": "Generate PPT presentations from a prompt using Felo AI",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./felo-slides"
+      ]
+    },
+    {
+      "name": "felo-superAgent",
+      "description": "SuperAgent conversation with SSE streaming and LiveDoc integration",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./felo-superAgent"
+      ]
+    },
+    {
+      "name": "felo-web-fetch",
+      "description": "Fetch and extract webpage content in markdown, text, or HTML format",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./felo-web-fetch"
+      ]
+    },
+    {
+      "name": "felo-youtube-subtitling",
+      "description": "Fetch YouTube video subtitles and captions by URL or video ID",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./felo-youtube-subtitling"
+      ]
+    },
+    {
+      "name": "felo-x-search",
+      "description": "Search X (Twitter) tweets, users, and replies via Felo API",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./felo-x-search"
+      ]
+    },
+    {
+      "name": "felo-content-to-slides",
+      "description": "Fetch content from a webpage or YouTube video and generate a PPT",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./felo-content-to-slides"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `.claude-plugin/marketplace.json` to support `claude install` and `/plugin marketplace add Felo-Inc/felo-skills`
- Registers all 8 felo skills: search, livedoc, slides, superAgent, web-fetch, youtube-subtitling, x-search, content-to-slides
- Bump version to 0.2.29
- Fix spinner animation in non-TTY environments (Claude Code TUI, pipes, CI)

## Test plan

- [ ] `/plugin marketplace add Felo-Inc/felo-skills` — should succeed
- [ ] `/plugin install felo-livedoc@felo-ai` — should install
- [ ] Run `felo livedoc list` in terminal — spinner works normally
- [ ] Run `felo livedoc list | cat` — no repeated spinner lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)