### PR TITLE
feat: integrate PPT theme support and task resume

### DIFF
--- a/felo-content-to-slides/SKILL.md
+++ b/felo-content-to-slides/SKILL.md
@@ -56,6 +56,7 @@ felo content-to-slides -v "https://www.youtube.com/watch?v=ID" [options]
 | `-l, --language <code>` | For --video: subtitle language (e.g. en, zh-CN) |
 | `-t, --timeout <seconds>` | Fetch timeout (default 60) |
 | `--poll-timeout <seconds>` | Max seconds to wait for PPT task (default 1200) |
+| `--theme <id>` | PPT theme ID (list themes with `felo ppt-themes`) |
 | `-j, --json` | Output JSON with task_id and ppt/live_doc URL |
 | `--verbose` | Show polling status |
 
@@ -66,6 +67,9 @@ Provide **either** `--url` or `--video`, not both.
 ```bash
 # Web page → PPT (with readability)
 node src/cli.js content-to-slides --url "https://openclaw.ai/" --readability
+
+# Web page → PPT with a specific theme
+node src/cli.js content-to-slides --url "https://openclaw.ai/" --readability --theme "THEME_ID"
 
 # YouTube → PPT, with extra instruction
 node src/cli.js content-to-slides -v "https://www.youtube.com/watch?v=xxx" --extra-prompt "max 10 slides"

--- a/felo-slides/SKILL.md
+++ b/felo-slides/SKILL.md
@@ -75,9 +75,22 @@ node felo-slides/scripts/run_ppt_task.mjs \
   --timeout 60
 ```
 
+To apply a specific theme, first list available themes with `felo ppt-themes`, then pass the theme ID:
+
+```bash
+node felo-slides/scripts/run_ppt_task.mjs \
+  --query "USER_PROMPT_HERE" \
+  --theme "THEME_ID_HERE" \
+  --interval 10 \
+  --max-wait 1800 \
+  --timeout 60
+```
+
 Script behavior:
 
 - Creates task via `POST https://openapi.felo.ai/v2/ppts`
+- Supports optional `--theme <id>` to apply a PPT theme (sends `ppt_config.ai_theme_id`)
+- Supports optional `--task-id <id>` to resume polling an existing task (skips creation)
 - Polls via `GET https://openapi.felo.ai/v2/tasks/{task_id}/historical`
 - Treats `COMPLETED`/`SUCCESS` as success terminal (case-insensitive)
 - Treats `FAILED`/`ERROR` as failure terminal
@@ -152,6 +165,14 @@ Timeout handling:
 
 - If timeout reached, return last known status and instruct user to retry later
 - Include `task_id` so user can query again
+- **IMPORTANT**: To resume a timed-out task, use `--task-id` instead of `--query` to avoid creating a duplicate PPT:
+
+```bash
+node felo-slides/scripts/run_ppt_task.mjs \
+  --task-id "TASK_ID_HERE" \
+  --interval 10 \
+  --max-wait 1800
+```
 
 ## Important Notes
 

--- a/felo-slides/scripts/run_ppt_task.mjs
+++ b/felo-slides/scripts/run_ppt_task.mjs
@@ -12,7 +12,9 @@ function usage() {
       '  node felo-slides/scripts/run_ppt_task.mjs --query "your prompt" [options]',
       '',
       'Options:',
-      '  --query <text>        PPT prompt (required)',
+      '  --query <text>        PPT prompt (required unless --task-id is given)',
+      '  --task-id <id>        Resume polling an existing task (skip creation)',
+      '  --theme <id>          PPT theme ID (from ppt-themes)',
       '  --interval <seconds>  Poll interval, default 10',
       '  --max-wait <seconds>  Max wait time, default 1800',
       '  --timeout <seconds>   Request timeout, default 60',
@@ -26,6 +28,8 @@ function usage() {
 function parseArgs(argv) {
   const out = {
     query: '',
+    taskId: '',
+    theme: '',
     intervalSec: DEFAULT_INTERVAL_SEC,
     maxWaitSec: DEFAULT_MAX_WAIT_SEC,
     timeoutSec: DEFAULT_TIMEOUT_SEC,
@@ -43,6 +47,12 @@ function parseArgs(argv) {
       out.verbose = true;
     } else if (a === '--query') {
       out.query = argv[i + 1] ?? '';
+      i += 1;
+    } else if (a === '--task-id') {
+      out.taskId = argv[i + 1] ?? '';
+      i += 1;
+    } else if (a === '--theme') {
+      out.theme = argv[i + 1] ?? '';
       i += 1;
     } else if (a === '--interval') {
       out.intervalSec = Number.parseInt(argv[i + 1] ?? '', 10);
@@ -128,7 +138,11 @@ function extractTaskUrls(historicalData, createData) {
   };
 }
 
-async function createTask(apiKey, apiBase, query, timeoutMs) {
+async function createTask(apiKey, apiBase, query, timeoutMs, theme) {
+  const reqBody = { query };
+  if (theme) {
+    reqBody.ppt_config = { ai_theme_id: theme };
+  }
   const payload = await fetchJson(
     `${apiBase}/v2/ppts`,
     {
@@ -138,7 +152,7 @@ async function createTask(apiKey, apiBase, query, timeoutMs) {
         Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ query }),
+      body: JSON.stringify(reqBody),
     },
     timeoutMs
   );
@@ -170,7 +184,7 @@ async function main() {
     usage();
     process.exit(0);
   }
-  if (!args.query) {
+  if (!args.query && !args.taskId) {
     usage();
     process.exit(1);
   }
@@ -186,10 +200,22 @@ async function main() {
   const intervalMs = args.intervalSec * 1000;
   const maxWaitMs = args.maxWaitSec * 1000;
 
-  const createData = await createTask(apiKey, apiBase, args.query, timeoutMs);
-  const taskId = createData.task_id;
-  if (args.verbose) {
-    console.error(`Task ID: ${taskId}`);
+  let createData = {};
+  let taskId;
+
+  if (args.taskId) {
+    // Resume polling an existing task
+    taskId = args.taskId;
+    if (args.verbose) {
+      console.error(`Resuming task: ${taskId}`);
+    }
+  } else {
+    // Create a new task
+    createData = await createTask(apiKey, apiBase, args.query, timeoutMs, args.theme);
+    taskId = createData.task_id;
+    if (args.verbose) {
+      console.error(`Task ID: ${taskId}`);
+    }
   }
 
   const startAt = Date.now();

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,7 @@
 import { createRequire } from "module";
 import { Command } from "commander";
 import { search } from "./search.js";
-import { slides } from "./slides.js";
+import { slides, listPptThemes } from "./slides.js";
 import { superAgent, listLiveDocs, listLiveDocResources } from "./superAgent.js";
 import { webFetch } from "./webFetch.js";
 import { youtubeSubtitling } from "./youtubeSubtitling.js";
@@ -71,7 +71,7 @@ program
     "Generate PPT/slides from a prompt (async task, outputs live doc URL when done)"
   )
   .argument(
-    "<query>",
+    "[query]",
     'PPT generation prompt (e.g. "Felo, 2 pages" or "Introduction to React")'
   )
   .option("-j, --json", "output raw JSON with task_id and live_doc_url")
@@ -86,14 +86,49 @@ program
     "max seconds to wait for task completion",
     "1200"
   )
+  .option("--theme <id>", "PPT theme ID (from ppt-themes command)")
+  .option("--task-id <id>", "resume polling an existing task (skip creation)")
   .action(async (query, opts) => {
+    if (!query && !opts.taskId) {
+      console.error("Error: provide a <query> or --task-id to resume an existing task");
+      flushStdioThenExit(1);
+      return;
+    }
     const timeoutMs = parseInt(opts.timeout, 10) * 1000;
     const pollTimeoutMs = parseInt(opts.pollTimeout, 10) * 1000 || 1_200_000;
-    const code = await slides(query, {
+    const pptConfig = opts.theme ? { ai_theme_id: opts.theme } : undefined;
+    const code = await slides(query || "", {
       json: opts.json,
       verbose: opts.verbose,
       timeoutMs: Number.isNaN(timeoutMs) ? 60000 : timeoutMs,
       pollTimeoutMs: Number.isNaN(pollTimeoutMs) ? 1_200_000 : pollTimeoutMs,
+      pptConfig,
+      taskId: opts.taskId,
+    });
+    process.exitCode = code;
+    flushStdioThenExit(code);
+  });
+
+program
+  .command("ppt-themes")
+  .description("List available PPT themes with optional filtering")
+  .option("--lang <code>", "language code (e.g. en, zh-Hans)")
+  .option("--type <type>", "filter by theme type (e.g. default, custom)")
+  .option("-k, --keyword <keyword>", "search keyword for theme titles")
+  .option("-p, --page <number>", "page number (starting from 1)", "1")
+  .option("-s, --size <number>", "page size (max 100)", "20")
+  .option("-j, --json", "output raw JSON")
+  .option("-t, --timeout <seconds>", "request timeout in seconds", "60")
+  .action(async (opts) => {
+    const timeoutMs = parseInt(opts.timeout, 10) * 1000;
+    const code = await listPptThemes({
+      lang: opts.lang,
+      type: opts.type,
+      keyword: opts.keyword,
+      page: parseInt(opts.page, 10) || 1,
+      size: parseInt(opts.size, 10) || 20,
+      json: opts.json,
+      timeoutMs: Number.isNaN(timeoutMs) ? 60000 : timeoutMs,
     });
     process.exitCode = code;
     flushStdioThenExit(code);
@@ -341,6 +376,7 @@ program
   )
   .option("-j, --json", "Output JSON with task_id and ppt/live_doc URL")
   .option("--verbose", "Show polling status")
+  .option("--theme <id>", "PPT theme ID (from ppt-themes command)")
   .action(async (opts) => {
     const timeoutMs = parseInt(opts.timeout, 10) * 1000;
     const pollTimeoutMs = parseInt(opts.pollTimeout, 10) * 1000;
@@ -354,6 +390,7 @@ program
       pollTimeoutMs: Number.isNaN(pollTimeoutMs) ? 1_200_000 : pollTimeoutMs,
       json: opts.json,
       verbose: opts.verbose,
+      theme: opts.theme,
     });
     process.exitCode = code;
     flushStdioThenExit(code);

--- a/src/contentToSlides.js
+++ b/src/contentToSlides.js
@@ -77,5 +77,6 @@ export async function contentToSlides(opts) {
     verbose: opts?.verbose,
     timeoutMs: fetchTimeoutMs,
     pollTimeoutMs: opts?.pollTimeoutMs,
+    pptConfig: opts?.theme ? { ai_theme_id: opts.theme } : undefined,
   });
 }

--- a/src/slides.js
+++ b/src/slides.js
@@ -48,9 +48,18 @@ function normalizeTaskStatus(status) {
 /**
  * Create a PPT task. Returns { task_id, livedoc_short_id, ppt_business_id } or throws.
  * Uses fetchWithTimeoutAndRetry for 5xx retry (per PPT Task API error codes).
+ * @param {string} apiKey
+ * @param {string} query
+ * @param {number} timeoutMs
+ * @param {string} apiBase
+ * @param {{ ai_theme_id?: string }} [pptConfig]
  */
-async function createPptTask(apiKey, query, timeoutMs, apiBase) {
+async function createPptTask(apiKey, query, timeoutMs, apiBase, pptConfig) {
   const url = `${apiBase}/v2/ppts`;
+  const body = { query: query.trim() };
+  if (pptConfig && Object.keys(pptConfig).length > 0) {
+    body.ppt_config = pptConfig;
+  }
   const res = await fetchWithTimeoutAndRetry(
     url,
     {
@@ -60,7 +69,7 @@ async function createPptTask(apiKey, query, timeoutMs, apiBase) {
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ query: query.trim() }),
+      body: JSON.stringify(body),
     },
     timeoutMs
   );
@@ -150,18 +159,30 @@ export async function slides(query, options = {}) {
   try {
     const apiBase = await getApiBase();
 
-    process.stderr.write("Creating PPT task...\n");
+    let createResult = {};
+    let taskId;
 
-    const createResult = await createPptTask(
-      apiKey,
-      query,
-      requestTimeoutMs,
-      apiBase
-    );
-    const taskId = createResult.task_id;
+    if (options.taskId) {
+      // Resume polling an existing task
+      taskId = options.taskId;
+      if (options.verbose || options.json) {
+        process.stderr.write(`Resuming task: ${taskId}\n`);
+      }
+    } else {
+      process.stderr.write("Creating PPT task...\n");
 
-    if (options.json && options.verbose) {
-      process.stderr.write(`Task ID: ${taskId}\n`);
+      createResult = await createPptTask(
+        apiKey,
+        query,
+        requestTimeoutMs,
+        apiBase,
+        options.pptConfig
+      );
+      taskId = createResult.task_id;
+
+      if (options.json && options.verbose) {
+        process.stderr.write(`Task ID: ${taskId}\n`);
+      }
     }
 
     // 默认显示 spinner 动画；仅在使用 -v/--json 时改为逐行状态输出
@@ -326,6 +347,82 @@ export async function slides(query, options = {}) {
   } catch (err) {
     if (process.stderr.isTTY && !options.verbose && !options.json)
       clearStatusLine();
+    console.error("Error:", err.message || err);
+    return 1;
+  }
+}
+
+/**
+ * List available PPT themes. Returns exit code (0 success, 1 failure).
+ * @param {Object} options - { lang?, type?, keyword?, page?, size?, json?, timeoutMs? }
+ */
+export async function listPptThemes(options = {}) {
+  const apiKey = await getApiKey();
+  if (!apiKey) {
+    console.error(NO_KEY_MESSAGE.trim());
+    return 1;
+  }
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+
+  try {
+    const apiBase = await getApiBase();
+    const params = new URLSearchParams();
+    if (options.lang) params.set("lang", options.lang);
+    if (options.type) params.set("type", options.type);
+    if (options.keyword) params.set("keyword", options.keyword);
+    if (options.page) params.set("page", String(options.page));
+    if (options.size) params.set("size", String(options.size));
+
+    const qs = params.toString();
+    const url = `${apiBase}/v2/ppt-themes${qs ? `?${qs}` : ""}`;
+
+    const res = await fetchWithTimeoutAndRetry(
+      url,
+      {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+      },
+      timeoutMs
+    );
+
+    const data = await res.json().catch(() => ({}));
+
+    if (data.status === "error") {
+      const msg = data.message || data.code || "Unknown error";
+      throw new Error(msg);
+    }
+
+    if (!res.ok) {
+      const msg =
+        data.message || data.error || res.statusText || `HTTP ${res.status}`;
+      throw new Error(msg);
+    }
+
+    const themes = data.data ?? [];
+
+    if (options.json) {
+      console.log(JSON.stringify(data, null, 2));
+      return 0;
+    }
+
+    if (!Array.isArray(themes) || themes.length === 0) {
+      console.log("No themes found.");
+      return 0;
+    }
+
+    for (const t of themes) {
+      console.log(`${t.id}  ${t.title || "(untitled)"}`);
+      if (t.subtitle) console.log(`  subtitle: ${t.subtitle}`);
+      if (t.description) console.log(`  ${t.description}`);
+      console.log();
+    }
+
+    return 0;
+  } catch (err) {
     console.error("Error:", err.message || err);
     return 1;
   }


### PR DESCRIPTION
## Summary

- Add `ppt-themes` CLI command to list/search available PPT themes (`GET /v2/ppt-themes`)
- Add `--theme <id>` option to `slides`, `content-to-slides` commands and standalone script, passing `ppt_config.ai_theme_id` to `POST /v2/ppts`
- Add `--task-id <id>` option to resume polling an existing task without re-creating a duplicate PPT

Closes #60

## Test plan

- [x] `felo ppt-themes --help` shows all filter options
- [x] `felo slides --help` shows `--theme` and `--task-id` options
- [x] `felo content-to-slides --help` shows `--theme` option
- [x] Standalone script `--help` shows `--theme` and `--task-id`
- [x] `felo slides` without args shows clear error message
- [x] Existing tests pass (17/17)
- [ ] Manual test: `felo ppt-themes` returns theme list
- [ ] Manual test: `felo slides "topic" --theme <id>` creates themed PPT
- [ ] Manual test: `felo slides --task-id <id>` resumes polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)