### PR TITLE
feat: add apple-buy-advisor CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ felo livedoc retrieve SHORT_ID --query "search query"
 **Apple Buy Advisor** — [full options →](./apple-buy-advisor/SKILL.md)
 
 ```bash
+# Use as Felo CLI command
+felo apple-buy-advisor "Should I buy MacBook Pro M4?"
+felo apple-buy-advisor "Compare iPhone 17 vs iPhone 17e"
+felo apple-buy-advisor "Is it worth upgrading to iPad Air 13?"
+```
+
+```bash
 # Use as Claude Code skill
 /apple-buy-advisor Should I buy MacBook Pro M4?
 /apple-buy-advisor Compare iPhone 17 vs iPhone 17e

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "commander": "^12.0.0"
   },
   "scripts": {
-    "test": "node --test tests/",
+    "test": "node --test \"tests/*.test.js\"",
     "publish:local": "npm publish"
   }
 }

--- a/src/appleBuyAdvisor.js
+++ b/src/appleBuyAdvisor.js
@@ -1,0 +1,17 @@
+import { superAgent } from './superAgent.js';
+
+function buildAppleBuyAdvisorPrompt(query) {
+  const trimmed = String(query || '').trim();
+  return [
+    `/apple-buy-advisor ${trimmed}`,
+    '',
+    'If slash-style skill routing is unavailable, still act as an Apple product buy advisor.',
+    'Use current information, compare relevant Apple models, summarize user and professional feedback when possible, and end with a clear buying recommendation.',
+  ].join('\n');
+}
+
+export async function appleBuyAdvisor(query, options = {}) {
+  return superAgent(buildAppleBuyAdvisorPrompt(query), options);
+}
+
+export { buildAppleBuyAdvisorPrompt };

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,6 +5,7 @@ import { Command } from "commander";
 import { search } from "./search.js";
 import { slides, listPptThemes } from "./slides.js";
 import { superAgent, listLiveDocs, listLiveDocResources } from "./superAgent.js";
+import { appleBuyAdvisor } from "./appleBuyAdvisor.js";
 import { webFetch } from "./webFetch.js";
 import { youtubeSubtitling } from "./youtubeSubtitling.js";
 import { contentToSlides } from "./contentToSlides.js";
@@ -170,6 +171,30 @@ program
       skillId: opts.skillId || undefined,
       selectedResourceIds: opts.selectedResourceIds ? opts.selectedResourceIds.split(',').map(s => s.trim()).filter(Boolean) : undefined,
       ext,
+      acceptLanguage: opts.acceptLanguage || undefined,
+    });
+    process.exitCode = code;
+    flushStdioThenExit(code);
+  });
+
+program
+  .command("apple-buy-advisor")
+  .description("Research and compare Apple products before you buy")
+  .argument("<query>", "Apple product buying or comparison question")
+  .option("-j, --json", "output JSON with answer, thread_short_id, live_doc_short_id")
+  .option("-v, --verbose", "log stream key, thread ID, LiveDoc ID to stderr")
+  .option("-t, --timeout <seconds>", "request/stream timeout in seconds", "60")
+  .option("--live-doc-id <id>", "reuse existing LiveDoc short_id for continuous conversation")
+  .option("--thread-id <id>", "existing thread/conversation ID for follow-up questions")
+  .option("--accept-language <lang>", "language preference (e.g. zh, en)")
+  .action(async (query, opts) => {
+    const timeoutMs = parseInt(opts.timeout, 10) * 1000;
+    const code = await appleBuyAdvisor(query, {
+      json: opts.json,
+      verbose: opts.verbose,
+      timeoutMs: Number.isNaN(timeoutMs) ? 60000 : timeoutMs,
+      liveDocId: opts.liveDocId || undefined,
+      threadId: opts.threadId || undefined,
       acceptLanguage: opts.acceptLanguage || undefined,
     });
     process.exitCode = code;

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+const cliPath = path.resolve('src/cli.js');
+
+describe('CLI command registration', () => {
+  it('shows apple-buy-advisor in top-level help', () => {
+    const result = spawnSync(process.execPath, [cliPath, '--help'], {
+      encoding: 'utf8',
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.match(result.stdout, /apple-buy-advisor/);
+  });
+
+  it('shows help for apple-buy-advisor command', () => {
+    const result = spawnSync(process.execPath, [cliPath, 'apple-buy-advisor', '--help'], {
+      encoding: 'utf8',
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.match(result.stdout, /Research and compare Apple products before you buy/);
+  });
+});


### PR DESCRIPTION
- Add apple-buy-advisor command for Apple product research
- Update README with CLI usage examples
- Fix test script path matching in package.json
- Add CLI command registration tests