### PR TITLE
[main] [felo-slides] How-to-Execute workflow is missing Step 3

### DIFF
--- a/felo-slides/SKILL.md
+++ b/felo-slides/SKILL.md
@@ -119,6 +119,17 @@ This outputs structured JSON including:
 - `ppt_business_id`
 - `error_message`
 
+### Step 3: Confirm terminal status
+
+The script polls the historical endpoint automatically. Wait for it to exit
+before responding:
+
+- Success: terminal status is `COMPLETED` or `SUCCESS`, and the script prints
+  `ppt_url` (fallback: `live_doc_url`)
+- Failure: terminal status is `FAILED` or `ERROR`; return the error format below
+- Timeout: include the `task_id` and tell the user to resume with `--task-id`
+  instead of creating a duplicate PPT task
+
 ### Step 4: Return structured result
 
 On success, return:


### PR DESCRIPTION
## Description
Fixes the missing Step 3 in the `felo-slides` How to Execute workflow.

## Related Issues
Related to #94

## Changes
- Added `### Step 3: Confirm terminal status` to `felo-slides/SKILL.md`
- Clarified success, failure, and timeout handling before returning results

## Test Report
- `rg -n "^### Step [0-9]:" felo-slides/SKILL.md` confirms Step 1-4 sequence
- `npm test` currently fails before this docs change due the existing test script resolving `tests/` as a module
- `node --test tests/*.test.js` runs 17/19 tests; the 2 CLI help tests fail because dependencies are not installed locally (`commander` module missing)

## Checklist
- [x] Code has been self-tested
- [x] No obvious bugs
- [x] Ready for code review
