### PR TITLE
feat：支持基于本地文件和图片生成 PPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $env:FELO_API_KEY="..."             # Windows (PowerShell)
 | Command                                  | Description                                           |
 | ---------------------------------------- | ----------------------------------------------------- |
 | `felo search "<query>"`                  | Search for current info (weather, news, prices, etc.) |
-| `felo slides "<prompt>"`                 | Generate PPT; returns link when done                  |
+| `felo slides "<prompt>" [--file <path>]` | Generate PPT from a prompt or local file              |
 | `felo mindmap "<query>"`                 | Generate mindmap; returns link immediately            |
 | `felo web-fetch --url <url>`             | Fetch webpage content (markdown/text/html)            |
 | `felo youtube-subtitling -v <url-or-id>` | Fetch YouTube video subtitles                         |
@@ -77,6 +77,7 @@ felo search "MacBook Air M3 price" --json
 ```bash
 felo slides "Felo product intro, 3 slides"
 felo slides "Q4 2024 business review, 10 pages" --poll-timeout 300
+felo slides "Create 2 slides and include the original image" --file "/absolute/path/to/source.jpg"
 ```
 
 **Mindmap**

--- a/felo-slides/README.md
+++ b/felo-slides/README.md
@@ -5,6 +5,8 @@ Generate presentation slides with the Felo PPT Task API (asynchronous workflow).
 ## Features
 
 - Generate a PPT deck from a single prompt
+- Generate a PPT from a local image, PDF, or document
+- Preserve an uploaded image as source material for the generated slides
 - Poll task status automatically until completion/failure/timeout
 - Return `ppt_url` immediately when the task is completed (fallback to `live_doc_url`)
 - Return `task_id` for follow-up tracking
@@ -66,6 +68,22 @@ Internal script example:
 node felo-slides/scripts/run_ppt_task.mjs --query "Felo product intro, 3 slides" --interval 10 --max-wait 1800
 ```
 
+Upload a local file or image as PPT context:
+
+```bash
+node felo-slides/scripts/run_ppt_task.mjs \
+  --query "Create exactly 2 slides and place the original image directly in the PPT" \
+  --file "/absolute/path/to/source.jpg" \
+  --interval 10 \
+  --max-wait 1800
+```
+
+The npm CLI supports the same workflow:
+
+```bash
+felo slides "Create 2 slides from this image" --file "/absolute/path/to/source.jpg"
+```
+
 ## Troubleshooting
 
 ### `FELO_API_KEY` is missing
@@ -86,6 +104,6 @@ Use the returned `task_id` to query historical endpoint again.
 
 ## Links
 
-- [PPT Task API](https://openapi.felo.ai/docs/api-reference/v2/ppt-tasks.html)
+- [PPT Task API](https://openapi.felo.ai/docs/api-reference/ppt-tasks)
 - [Felo Open Platform](https://openapi.felo.ai/docs/)
 - [Get API Key](https://felo.ai)

--- a/felo-slides/SKILL.md
+++ b/felo-slides/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: felo-slides
-description: "Generate PPT/slides with Felo PPT Task API in Claude Code. Use when users ask to create/make/generate/export presentations or slide decks, or when explicit commands like /felo-slides are used. Handles API key check, task creation, polling, and final ppt_url output."
+description: "Generate PPT/slides from prompts, local images, PDFs, and other files with the Felo PPT Task API. Use when users ask to create, make, generate, or export presentations or slide decks; turn an attached/local file into slides; include an original image in a PPT; or explicitly invoke /felo-slides. Handles file upload, API key checks, task creation, polling, and final ppt_url output."
 ---
 
 # Felo Slides Skill
@@ -11,6 +11,8 @@ Trigger this skill for requests about creating presentation files:
 
 - Create/generate slides from a topic or outline
 - Turn notes into a PPT deck
+- Build slides from a local image, PDF, or document
+- Put an uploaded original image into the generated PPT
 - Build a presentation with a page count requirement
 - Export presentation content into a shareable slide link
 
@@ -75,6 +77,22 @@ node felo-slides/scripts/run_ppt_task.mjs \
   --timeout 60
 ```
 
+When the user provides a local image or file, pass its absolute path with
+`--file`. Include the desired use of the original asset in the prompt. For
+example:
+
+```bash
+node felo-slides/scripts/run_ppt_task.mjs \
+  --query "Create exactly 2 slides and place the uploaded original image directly in the PPT" \
+  --file "/absolute/path/to/source.jpg" \
+  --interval 10 \
+  --max-wait 1800 \
+  --timeout 60
+```
+
+Do not replace `--file` with a textual description when the user explicitly
+wants the original file or image used in the PPT.
+
 To apply a specific theme, first list available themes with `felo ppt-themes`, then pass the theme ID:
 
 ```bash
@@ -89,6 +107,7 @@ node felo-slides/scripts/run_ppt_task.mjs \
 Script behavior:
 
 - Creates task via `POST https://openapi.felo.ai/v2/ppts`
+- Supports optional `--file <path>` to upload one local file with `multipart/form-data`
 - Supports optional `--theme <id>` to apply a PPT theme (sends `ppt_config.ai_theme_id`)
 - Supports optional `--livedoc-id <id>` to reuse an existing LiveDoc instead of auto-creating a new one
 - Supports optional `--task-id <id>` to resume polling an existing task (skips creation)
@@ -195,5 +214,5 @@ node felo-slides/scripts/run_ppt_task.mjs \
 
 ## References
 
-- [Felo PPT Task API](https://openapi.felo.ai/docs/api-reference/v2/ppt-tasks.html)
+- [Felo PPT Task API](https://openapi.felo.ai/docs/api-reference/ppt-tasks)
 - [Felo Open Platform](https://openapi.felo.ai/docs/)

--- a/felo-slides/clawhub.json
+++ b/felo-slides/clawhub.json
@@ -1,9 +1,9 @@
 {
   "name": "Felo Slides",
-  "tagline": "Generate PPT/slides with Felo PPT Task API in Claude Code",
-  "description": "Felo Slides creates presentation decks from a prompt using the Felo PPT Task API: API key check, task creation, polling, theme support, task resume, and final ppt_url output. Use from Claude Code when users ask to create or export slides/PPT.",
+  "tagline": "Generate PPT/slides from prompts, images, and files with Felo",
+  "description": "Felo Slides creates presentation decks from prompts or uploaded local files using the Felo PPT Task API. It supports images, PDFs, documents, themes, task resume, polling, and final ppt_url output.",
   "category": "productivity",
-  "tags": ["felo", "slides", "ppt", "presentation", "api", "claude-code"],
+  "tags": ["felo", "slides", "ppt", "presentation", "file-upload", "image", "api", "claude-code"],
   "version": "1.0.1",
   "license": "MIT",
   "pricing": "free",

--- a/felo-slides/scripts/run_ppt_task.mjs
+++ b/felo-slides/scripts/run_ppt_task.mjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+import { readFile } from 'node:fs/promises';
+import { basename, extname } from 'node:path';
+
 const DEFAULT_API_BASE = 'https://openapi.felo.ai';
 const DEFAULT_INTERVAL_SEC = 10;
 const DEFAULT_MAX_WAIT_SEC = 1800;
@@ -15,6 +18,7 @@ function usage() {
       '  --query <text>        PPT prompt (required unless --task-id is given)',
       '  --task-id <id>        Resume polling an existing task (skip creation)',
       '  --theme <id>          PPT theme ID (from ppt-themes)',
+      '  --file <path>         Upload a local file or image as PPT context',
       '  --livedoc-id <id>     Reuse an existing LiveDoc instead of auto-creating one',
       '  --interval <seconds>  Poll interval, default 10',
       '  --max-wait <seconds>  Max wait time, default 1800',
@@ -31,6 +35,7 @@ function parseArgs(argv) {
     query: '',
     taskId: '',
     theme: '',
+    file: '',
     livedocId: '',
     intervalSec: DEFAULT_INTERVAL_SEC,
     maxWaitSec: DEFAULT_MAX_WAIT_SEC,
@@ -55,6 +60,9 @@ function parseArgs(argv) {
       i += 1;
     } else if (a === '--theme') {
       out.theme = argv[i + 1] ?? '';
+      i += 1;
+    } else if (a === '--file') {
+      out.file = argv[i + 1] ?? '';
       i += 1;
     } else if (a === '--livedoc-id') {
       out.livedocId = argv[i + 1] ?? '';
@@ -81,6 +89,29 @@ function parseArgs(argv) {
 
 function normalizeStatus(v) {
   return String(v ?? '').trim().toUpperCase();
+}
+
+function getFileContentType(filePath) {
+  const types = {
+    '.bmp': 'image/bmp',
+    '.csv': 'text/csv',
+    '.doc': 'application/msword',
+    '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    '.gif': 'image/gif',
+    '.jpeg': 'image/jpeg',
+    '.jpg': 'image/jpeg',
+    '.md': 'text/markdown',
+    '.pdf': 'application/pdf',
+    '.png': 'image/png',
+    '.ppt': 'application/vnd.ms-powerpoint',
+    '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    '.svg': 'image/svg+xml',
+    '.txt': 'text/plain',
+    '.webp': 'image/webp',
+    '.xls': 'application/vnd.ms-excel',
+    '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  };
+  return types[extname(filePath).toLowerCase()] || 'application/octet-stream';
 }
 
 function sleep(ms) {
@@ -143,24 +174,49 @@ function extractTaskUrls(historicalData, createData) {
   };
 }
 
-async function createTask(apiKey, apiBase, query, timeoutMs, theme, livedocId) {
-  const reqBody = { query };
-  if (theme) {
-    reqBody.ppt_config = { ai_theme_id: theme };
+async function createTask(apiKey, apiBase, query, timeoutMs, theme, livedocId, filePath) {
+  let body;
+  const headers = {
+    Accept: 'application/json',
+    Authorization: `Bearer ${apiKey}`,
+  };
+
+  if (filePath) {
+    const fileBytes = await readFile(filePath);
+    body = new FormData();
+    body.append('query', query);
+    if (theme) {
+      body.append(
+        'ppt_config',
+        new Blob([JSON.stringify({ ai_theme_id: theme })], { type: 'application/json' })
+      );
+    }
+    if (livedocId) {
+      body.append('livedoc_short_id', livedocId);
+    }
+    body.append(
+      'file',
+      new Blob([fileBytes], { type: getFileContentType(filePath) }),
+      basename(filePath)
+    );
+  } else {
+    const reqBody = { query };
+    if (theme) {
+      reqBody.ppt_config = { ai_theme_id: theme };
+    }
+    if (livedocId) {
+      reqBody.livedoc_short_id = livedocId;
+    }
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(reqBody);
   }
-  if (livedocId) {
-    reqBody.livedoc_short_id = livedocId;
-  }
+
   const payload = await fetchJson(
     `${apiBase}/v2/ppts`,
     {
       method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(reqBody),
+      headers,
+      body,
     },
     timeoutMs
   );
@@ -196,6 +252,9 @@ async function main() {
     usage();
     process.exit(1);
   }
+  if (args.taskId && args.file) {
+    throw new Error('--file cannot be used with --task-id');
+  }
 
   const apiKey = process.env.FELO_API_KEY?.trim();
   if (!apiKey) {
@@ -219,7 +278,15 @@ async function main() {
     }
   } else {
     // Create a new task
-    createData = await createTask(apiKey, apiBase, args.query, timeoutMs, args.theme, args.livedocId || undefined);
+    createData = await createTask(
+      apiKey,
+      apiBase,
+      args.query,
+      timeoutMs,
+      args.theme,
+      args.livedocId || undefined,
+      args.file || undefined
+    );
     taskId = createData.task_id;
     if (args.verbose) {
       console.error(`Task ID: ${taskId}`);
@@ -282,4 +349,3 @@ main().catch((err) => {
   console.error(`ERROR: ${err?.message || err}`);
   process.exit(1);
 });
-

--- a/src/cli.js
+++ b/src/cli.js
@@ -89,11 +89,17 @@ program
     "1200"
   )
   .option("--theme <id>", "PPT theme ID (from ppt-themes command)")
+  .option("--file <path>", "upload a local file or image and use it as PPT context")
   .option("--task-id <id>", "resume polling an existing task (skip creation)")
   .option("--livedoc-id <id>", "reuse an existing LiveDoc short_id instead of auto-creating a new one")
   .action(async (query, opts) => {
     if (!query && !opts.taskId) {
       console.error("Error: provide a <query> or --task-id to resume an existing task");
+      flushStdioThenExit(1);
+      return;
+    }
+    if (opts.taskId && opts.file) {
+      console.error("Error: --file cannot be used with --task-id");
       flushStdioThenExit(1);
       return;
     }
@@ -108,6 +114,7 @@ program
       pptConfig,
       taskId: opts.taskId,
       livedocShortId: opts.livedocId || undefined,
+      filePath: opts.file || undefined,
     });
     process.exitCode = code;
     flushStdioThenExit(code);

--- a/src/slides.js
+++ b/src/slides.js
@@ -3,6 +3,8 @@ import {
   fetchWithTimeoutAndRetry,
   NO_KEY_MESSAGE,
 } from "./search.js";
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
 
 const DEFAULT_API_BASE = "https://openapi.felo.ai";
 const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
@@ -45,6 +47,29 @@ function normalizeTaskStatus(status) {
     .toUpperCase();
 }
 
+function getFileContentType(filePath) {
+  const types = {
+    ".bmp": "image/bmp",
+    ".csv": "text/csv",
+    ".doc": "application/msword",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".gif": "image/gif",
+    ".jpeg": "image/jpeg",
+    ".jpg": "image/jpeg",
+    ".md": "text/markdown",
+    ".pdf": "application/pdf",
+    ".png": "image/png",
+    ".ppt": "application/vnd.ms-powerpoint",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".svg": "image/svg+xml",
+    ".txt": "text/plain",
+    ".webp": "image/webp",
+    ".xls": "application/vnd.ms-excel",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  };
+  return types[extname(filePath).toLowerCase()] || "application/octet-stream";
+}
+
 /**
  * Create a PPT task. Returns { task_id, livedoc_short_id, ppt_business_id } or throws.
  * Uses fetchWithTimeoutAndRetry for 5xx retry (per PPT Task API error codes).
@@ -54,26 +79,52 @@ function normalizeTaskStatus(status) {
  * @param {string} apiBase
  * @param {{ ai_theme_id?: string }} [pptConfig]
  * @param {string} [livedocShortId]
+ * @param {string} [filePath]
  */
-async function createPptTask(apiKey, query, timeoutMs, apiBase, pptConfig, livedocShortId) {
+async function createPptTask(apiKey, query, timeoutMs, apiBase, pptConfig, livedocShortId, filePath) {
   const url = `${apiBase}/v2/ppts`;
-  const body = { query: query.trim() };
-  if (pptConfig && Object.keys(pptConfig).length > 0) {
-    body.ppt_config = pptConfig;
+  let body;
+  const headers = {
+    Accept: "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+
+  if (filePath) {
+    const fileBytes = await readFile(filePath);
+    body = new FormData();
+    body.append("query", query.trim());
+    if (pptConfig && Object.keys(pptConfig).length > 0) {
+      body.append(
+        "ppt_config",
+        new Blob([JSON.stringify(pptConfig)], { type: "application/json" })
+      );
+    }
+    if (livedocShortId) {
+      body.append("livedoc_short_id", livedocShortId);
+    }
+    body.append(
+      "file",
+      new Blob([fileBytes], { type: getFileContentType(filePath) }),
+      basename(filePath)
+    );
+  } else {
+    body = { query: query.trim() };
+    if (pptConfig && Object.keys(pptConfig).length > 0) {
+      body.ppt_config = pptConfig;
+    }
+    if (livedocShortId) {
+      body.livedoc_short_id = livedocShortId;
+    }
+    headers["Content-Type"] = "application/json";
+    body = JSON.stringify(body);
   }
-  if (livedocShortId) {
-    body.livedoc_short_id = livedocShortId;
-  }
+
   const res = await fetchWithTimeoutAndRetry(
     url,
     {
       method: "POST",
-      headers: {
-        Accept: "application/json",
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
+      headers,
+      body,
     },
     timeoutMs
   );
@@ -181,7 +232,8 @@ export async function slides(query, options = {}) {
         requestTimeoutMs,
         apiBase,
         options.pptConfig,
-        options.livedocShortId
+        options.livedocShortId,
+        options.filePath
       );
       taskId = createResult.task_id;
 

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -23,4 +23,14 @@ describe('CLI command registration', () => {
     assert.strictEqual(result.status, 0);
     assert.match(result.stdout, /Research and compare Apple products before you buy/);
   });
+
+  it('shows file upload support for slides', () => {
+    const result = spawnSync(process.execPath, [cliPath, 'slides', '--help'], {
+      encoding: 'utf8',
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.match(result.stdout, /--file <path>/);
+    assert.match(result.stdout, /upload a local file or image/i);
+  });
 });

--- a/tests/slides-file.test.js
+++ b/tests/slides-file.test.js
@@ -1,0 +1,162 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { slides } from '../src/slides.js';
+
+const originalFetch = globalThis.fetch;
+const originalApiKey = process.env.FELO_API_KEY;
+const originalApiBase = process.env.FELO_API_BASE;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalApiKey === undefined) delete process.env.FELO_API_KEY;
+  else process.env.FELO_API_KEY = originalApiKey;
+  if (originalApiBase === undefined) delete process.env.FELO_API_BASE;
+  else process.env.FELO_API_BASE = originalApiBase;
+});
+
+describe('slides file upload', () => {
+  it('uses multipart form data in the CLI implementation', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'felo-slides-'));
+    const filePath = path.join(tempDir, 'source.jpg');
+    await writeFile(filePath, Buffer.from('image-bytes'));
+
+    process.env.FELO_API_KEY = 'test-key';
+    process.env.FELO_API_BASE = 'https://mock.felo.test';
+    const calls = [];
+    globalThis.fetch = async (url, init) => {
+      calls.push({ url: String(url), init });
+      if (String(url).endsWith('/v2/ppts')) {
+        assert.ok(init.body instanceof FormData);
+        assert.strictEqual(init.headers['Content-Type'], undefined);
+        assert.strictEqual(init.body.get('query'), 'Use the original image in 2 slides');
+        assert.strictEqual(init.body.get('livedoc_short_id'), 'live-123');
+
+        const config = init.body.get('ppt_config');
+        assert.strictEqual(config.type, 'application/json');
+        assert.deepStrictEqual(JSON.parse(await config.text()), { ai_theme_id: 'theme-123' });
+
+        const file = init.body.get('file');
+        assert.strictEqual(file.name, 'source.jpg');
+        assert.strictEqual(file.type, 'image/jpeg');
+        assert.strictEqual(await file.text(), 'image-bytes');
+
+        return Response.json({
+          status: 200,
+          code: 'OK',
+          data: { task_id: 'task-123', livedoc_short_id: 'live-123', ppt_business_id: 'ppt-123' },
+        });
+      }
+
+      return Response.json({
+        status: 200,
+        code: 'OK',
+        data: { task_status: 'COMPLETED', ppt_url: 'https://felo.ai/slides/ppt-123' },
+      });
+    };
+
+    try {
+      const code = await slides('Use the original image in 2 slides', {
+        filePath,
+        livedocShortId: 'live-123',
+        pptConfig: { ai_theme_id: 'theme-123' },
+        pollIntervalMs: 0,
+        pollTimeoutMs: 1_000,
+        json: true,
+      });
+      assert.strictEqual(code, 0);
+      assert.strictEqual(calls.length, 2);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uploads a file through the bundled skill runner', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'felo-slides-runner-'));
+    const filePath = path.join(tempDir, 'source.jpg');
+    await writeFile(filePath, Buffer.from('runner-image-bytes'));
+
+    const requests = [];
+    const server = createServer((req, res) => {
+      const chunks = [];
+      req.on('data', (chunk) => chunks.push(chunk));
+      req.on('end', () => {
+        requests.push({
+          method: req.method,
+          url: req.url,
+          contentType: req.headers['content-type'] || '',
+          body: Buffer.concat(chunks).toString('utf8'),
+        });
+        res.setHeader('Content-Type', 'application/json');
+        if (req.method === 'POST') {
+          res.end(JSON.stringify({
+            status: 200,
+            code: 'OK',
+            data: { task_id: 'task-runner', livedoc_short_id: 'live-runner', ppt_business_id: 'ppt-runner' },
+          }));
+        } else {
+          res.end(JSON.stringify({
+            status: 200,
+            code: 'OK',
+            data: { task_status: 'COMPLETED', ppt_url: 'https://felo.ai/slides/ppt-runner' },
+          }));
+        }
+      });
+    });
+
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+
+    try {
+      const result = await new Promise((resolve, reject) => {
+        const child = spawn(
+          process.execPath,
+          [
+            'felo-slides/scripts/run_ppt_task.mjs',
+            '--query', 'Use this image in 2 slides',
+            '--file', filePath,
+            '--theme', 'theme-runner',
+            '--interval', '1',
+            '--max-wait', '5',
+            '--json',
+          ],
+          {
+            cwd: path.resolve('.'),
+            env: {
+              ...process.env,
+              FELO_API_KEY: 'test-key',
+              FELO_API_BASE: `http://127.0.0.1:${address.port}`,
+            },
+          }
+        );
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (chunk) => { stdout += chunk; });
+        child.stderr.on('data', (chunk) => { stderr += chunk; });
+        child.on('error', reject);
+        child.on('close', (code) => resolve({ code, stdout, stderr }));
+      });
+
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.strictEqual(JSON.parse(result.stdout).data.task_id, 'task-runner');
+      assert.strictEqual(requests.length, 2);
+
+      const upload = requests[0];
+      assert.match(upload.contentType, /^multipart\/form-data; boundary=/);
+      assert.match(upload.body, /name="query"/);
+      assert.match(upload.body, /Use this image in 2 slides/);
+      assert.match(upload.body, /name="ppt_config"/);
+      assert.match(upload.body, /theme-runner/);
+      assert.match(upload.body, /name="file"; filename="source.jpg"/);
+      assert.match(upload.body, /Content-Type: image\/jpeg/i);
+      assert.match(upload.body, /runner-image-bytes/);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 背景

PPT Task API 已支持 multipart 文件上传，但 felo-slides Skill 与 npm CLI 尚未暴露对应能力，无法直接将本地图片、PDF 或文档作为生成上下文。

## 主要改动

- 为 `felo slides` 增加 `--file <path>` 参数
- 为 bundled runner 增加同等文件上传能力
- 保留无文件场景原有 JSON 请求，确保向后兼容
- 保留文件名并识别常见图片、PDF 和 Office MIME 类型
- 更新 Skill 触发描述、README 与 ClawHub 元数据
- 增加 CLI 和本地模拟 API 的 multipart 回归测试

## 影响范围

仅影响 PPT 生成 CLI 与 felo-slides Skill；不涉及数据库、鉴权或其他 Skill。

## 测试说明

- `npm test`：22/22 通过
- Node 语法检查通过
- `npm pack --dry-run` 通过
- Skill quick validation 通过

Related: 无关联 Issue